### PR TITLE
Update base image from debian:bookworm-slim to debian:trixie-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY ./backend /app
 RUN cargo build --release
 
 # Runtime stage
-FROM debian:bookworm-slim AS run
+FROM debian:trixie-slim AS run
 RUN apt-get update && \
   apt-get install -y ca-certificates && \
   apt-get clean && \


### PR DESCRIPTION
To fix an issue with GLIBC when running the image after building

docker run --env-file ./configs/docker.env -p 8000:8000 -p 8888:8888/udp pinging:0.0.1 

/app/pinging: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/pinging)